### PR TITLE
Fix: no alert when stratum equal to given values

### DIFF
--- a/check_ntp_stratum
+++ b/check_ntp_stratum
@@ -33,8 +33,8 @@ sub check_ntp($opt, $np) {
 
 	my $code = $np->check_threshold(
 		check => $stratum,
-		warning => $opt->warning,
-		critical => $opt->critical
+		warning => $opt->warning - 1,
+		critical => $opt->critical - 1
 	);
 
 	$np->add_perfdata(


### PR DESCRIPTION
Before : 
./check_ntp_stratum -h  ntp.server.fr -w 2 -c 4
NTP_STRATUM OK - Stratum 2 offset -0.032711 | stratum=2;2;4;1;16 offset=-0.0327107906341553;;

Expected result is a warning.

After patch : 
./check_ntp_stratum -h  ntp.server.fr -w 2 -c 3
NTP_STRATUM WARNING - Stratum 2 offset -0.030255 | stratum=2;2;3;1;16 offset=-0.0302551984786987;;
